### PR TITLE
Remove secure: key from file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script:
 deploy:
   provider: heroku
   api_key:
-    secure: ENV[MAP_API_KEY]
+    secure: 
   app: go-local-maps-api
   on:
     repo: Team-Go-Local/go_local_microservice


### PR DESCRIPTION
Notes:   Removed any api key reference from .travis.yml file to test if it can still deploy to heroku without it
